### PR TITLE
Make exercises more interesting by having two Spotify users on one task

### DIFF
--- a/lesson2/lesson2-data.sql
+++ b/lesson2/lesson2-data.sql
@@ -46,6 +46,7 @@ insert into user (id, name, email, phone) values (8, 'Hedy Gerault', 'hgerault7@
 insert into user (id, name, email, phone) values (9, '王秀英', 'wang.xiuying@weebly.com', '891-952-6749');
 insert into user (id, name, email, phone) values (10, 'إلياس', 'elias@github.com', '202-517-6983');
 insert into user (id, name, email, phone) values (11, 'Donald Duck', 'donald@duck.com', NULL);
+insert into user (id, name, email, phone) values (12, 'Landon Fitzgerald', 'fitzgerald@spotify.com', '967-596-8777');
 
 -- Statuses
 insert into status (id, name) values (1, 'Not started');
@@ -138,3 +139,4 @@ insert into user_task (user_id, task_id) values(8, 25);
 insert into user_task (user_id, task_id) values(9, 28);
 insert into user_task (user_id, task_id) values(10, 31);
 insert into user_task (user_id, task_id) values(11, 32);
+insert into user_task (user_id, task_id) values(12, 4);


### PR DESCRIPTION
The [week 2 part 3 exercise](https://github.com/HackYourFuture-CPH/databases/blob/main/lesson2/README.md#part-3-more-queries) asks trainees to get all tasks assigned to a user with a Spotify email. A solution sometimes seen in homework submissions would show tasks multiple times if multiple users with a Spotify email are assigned the same task.

This PR aims to make this situation actually occur thus making it easier for trainees to discover the bug and come up with a fix.